### PR TITLE
Fix build with GCC 10.

### DIFF
--- a/toonz/sources/common/twain/twain.h
+++ b/toonz/sources/common/twain/twain.h
@@ -2209,7 +2209,7 @@ typedef struct {
 #elif defined(TWH_CMP_GNU)
 #pragma pack(pop, before_twain)
 #elif defined(TWH_CMP_BORLAND)
-#pragma option a.
+#pragma option -a.
 #elif defined(TWH_CMP_XCODE)
 #if PRAGMA_STRUCT_ALIGN
 #pragma options align = reset


### PR DESCRIPTION
The default option was fixed in the latest Twain releases but Opentoonz includes Twain 2.1.

P.S.
This is cherry-pick from https://github.com/opentoonz/opentoonz/commit/05ead497ad4d95cf5c37154b780724d67da93f55

Fixes build with MinGW too.

Currently build fails with following error:
```
/build/packet/win-64/opentoonz-me/build/opentoonz/toonz/sources/tnzbase/../common/twain/twain.h:2212:16: error: extended character  is not valid in an identifier
 2212 | #pragma option ��a.
```