### PR TITLE
(morevna): Fix splash gradient not rendering

### DIFF
--- a/toonz/sources/toonz/Resources/splash.svg
+++ b/toonz/sources/toonz/Resources/splash.svg
@@ -37,7 +37,6 @@
        width="610"
        y="708.36"
        x="0"
-       fill="#54458e"
        id="rect2"
        style="fill:url(#linearGradient1889);fill-opacity:1.0" />
     <path


### PR DESCRIPTION
The background `rect` in splash.svg had both a `fill="#54458e"` attribute and `style="fill:url(#linearGradient1889)"`. QtSvg incorrectly gives the presentation attribute priority over the style rule, so in the built app the background rendered as solid purple-blue instead of the gradient.

**Fix:** removed the `fill` attribute — the fill is now defined solely via `style`. Verified by rendering with QSvgRenderer: the `#0c0c0c → #393939` gradient displays correctly.